### PR TITLE
Let inventory script with in a virtualenv

### DIFF
--- a/inventory/virl.py
+++ b/inventory/virl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import sys


### PR DESCRIPTION
Don't default to using the system python.  Instead,
use the first python found in the path so that the script
will work within a venv with the correct libraries installed.